### PR TITLE
Set Pebbles git as the main source

### DIFF
--- a/com.github.subhadeepjasu.pebbles.yaml
+++ b/com.github.subhadeepjasu.pebbles.yaml
@@ -68,10 +68,13 @@ modules:
     buildsystem: meson
     sources:
       - type: git
-        is-main-source: true
         url: https://github.com/SubhadeepJasu/pebbles.git
         tag: v3.0.0
         commit: b2b7b6f10ea3703e10c9f4c566c6892f220250eb
+        x-checker-data:
+          is-main-source: true
+          type: git
+          tag-pattern: ^v([\d.]+)$
       - type: patch
         path: patches/blp-meson-temp.patch
     config-opts:

--- a/com.github.subhadeepjasu.pebbles.yaml
+++ b/com.github.subhadeepjasu.pebbles.yaml
@@ -68,6 +68,7 @@ modules:
     buildsystem: meson
     sources:
       - type: git
+        is-main-source: true
         url: https://github.com/SubhadeepJasu/pebbles.git
         tag: v3.0.0
         commit: b2b7b6f10ea3703e10c9f4c566c6892f220250eb

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64", "aarch64"]
+  "only-arches": ["x86_64", "aarch64"],
+  "require-important-update": true
 }


### PR DESCRIPTION
Set Pebbles git as the main source, to prevent noisy update check.